### PR TITLE
Fix compatibility with Visual Studio 2013

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -22,6 +22,16 @@ extern "C" {
 #include "frameobject.h"          // PyFrameObject, PyFrame_GetBack()
 
 
+// Compatibility with Visual Studio 2013 and older which don't support
+// the inline keyword in C (only in C++): use __inline instead.
+#if (defined(_MSC_VER) && _MSC_VER < 1900 \
+     && !defined(__cplusplus) && !defined(inline))
+#  define inline __inline
+#  define PYTHONCAPI_COMPAT_MSC_INLINE
+   // These two macros are undefined at the end of this file
+#endif
+
+
 // Cast argument to PyObject* type.
 #ifndef _PyObject_CAST
 #  define _PyObject_CAST(op) ((PyObject*)(op))
@@ -285,6 +295,11 @@ _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
 #define Py_IS_TYPE(ob, type) _Py_IS_TYPE(_PyObject_CAST_CONST(ob), type)
 #endif
 
+
+#ifdef PYTHONCAPI_COMPAT_MSC_INLINE
+#  undef inline
+#  undef PYTHONCAPI_COMPAT_MSC_INLINE
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Visual C++ 2008 fails with a compiler error on "inline" keyword when
building a C file.