### PR TITLE
Update the copyright

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright 2016, Red Hat, Inc. and Google Inc.
+Copyright Contributors to the pythoncapi_compat project.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -2,6 +2,7 @@
 // versions.
 //
 // File distributed under the MIT license.
+// Copyright Contributors to the pythoncapi_compat project.
 //
 // Homepage:
 // https://github.com/pythoncapi/pythoncapi_compat


### PR DESCRIPTION
The COPYING file was copied from https://github.com/psf/pyperf/
without updating the copyright.

Follow recommendations of the Linux Foundation:
https://www.linuxfoundation.org/en/blog/copyright-notices-in-open-source-software-projects/
