### PR TITLE
Fix pre-C99 compilation

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -278,8 +278,9 @@ PyObject_CallOneArg(PyObject *func, PyObject *arg)
 static inline int
 PyModule_AddObjectRef(PyObject *module, const char *name, PyObject *value)
 {
+    int res;
     Py_XINCREF(value);
-    int res = PyModule_AddObject(module, name, value);
+    res = PyModule_AddObject(module, name, value);
     if (res < 0) {
         Py_XDECREF(value);
     }


### PR DESCRIPTION
Unfortunately, building fails with MSVC in pre-C99 mode (compiling against Python 2.7):
```
c:\temp\bitarray\bitarray\pythoncapi_compat.h(264) : error C2143: syntax error : missing ';' before 'type'
c:\temp\bitarray\bitarray\pythoncapi_compat.h(265) : error C2065: 'res' : undeclared identifier
c:\temp\bitarray\bitarray\pythoncapi_compat.h(268) : error C2065: 'res' : undeclared identifier
```
Hopefully an uncontroversial fix!

Thanks, Andrew R