### PR TITLE
Add C++ support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,12 @@ pythoncapi_compat.h API
 The ``pythoncapi_compat.h`` header file provides implementations of recent
 functions for old Python versions.
 
-It supports Python 3.5 to Python 3.11, Python 2.7, PyPy 3.6 and PyPy 2.7.
+Supported Python versions:
+
+* Python 2.7, Python 3.5 - 3.11
+* PyPy 2.7, 3.6 and 3.7
+
+C++ is supported on Python 3.5 and newer.
 
 A C99 subset is required, like ``static inline`` functions: see `PEP 7
 <https://www.python.org/dev/peps/pep-0007/>`_.  ISO C90 is partially supported

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,7 @@ Supported Python versions:
 * Python 2.7, Python 3.5 - 3.11
 * PyPy 2.7, 3.6 and 3.7
 
-C++ is supported on Python 3.5 and newer.
+C++ is supported on Python 3.6 and newer.
 
 A C99 subset is required, like ``static inline`` functions: see `PEP 7
 <https://www.python.org/dev/peps/pep-0007/>`_.  ISO C90 is partially supported

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* 2022-02-09: ``pythoncapi_compat.h`` now supports C++ on Python 3.5 and newer:
+  use ``nullptr`` and ``reinterpret_cast<type>`` cast on C++, and use ``NULL``
+  and ``(type)`` cast on C.
 * 2021-10-15: Add ``PyThreadState_EnterTracing()`` and
   ``PyThreadState_LeaveTracing()``.
 * 2021-04-09: Add ``Py_Is()``, ``Py_IsNone()``, ``Py_IsTrue()``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-* 2022-02-09: ``pythoncapi_compat.h`` now supports C++ on Python 3.5 and newer:
+* 2022-02-09: ``pythoncapi_compat.h`` now supports C++ on Python 3.6 and newer:
   use ``nullptr`` and ``reinterpret_cast<type>`` cast on C++, and use ``NULL``
   and ``(type)`` cast on C.
 * 2021-10-15: Add ``PyThreadState_EnterTracing()`` and

--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -304,7 +304,7 @@ PyThreadState_LeaveTracing(PyThreadState *tstate)
 PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallNoArgs(PyObject *func)
 {
-    return PyObject_CallFunctionObjArgs(func, PYCAPI_COMPAT_NULL);
+    return PyObject_CallFunctionObjArgs(func, NULL);
 }
 #endif
 
@@ -315,7 +315,7 @@ PyObject_CallNoArgs(PyObject *func)
 PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallOneArg(PyObject *func, PyObject *arg)
 {
-    return PyObject_CallFunctionObjArgs(func, arg, PYCAPI_COMPAT_NULL);
+    return PyObject_CallFunctionObjArgs(func, arg, NULL);
 }
 #endif
 

--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -27,24 +27,34 @@ extern "C" {
 // the inline keyword in C (only in C++): use __inline instead.
 #if (defined(_MSC_VER) && _MSC_VER < 1900 \
      && !defined(__cplusplus) && !defined(inline))
-#  define inline __inline
-#  define PYTHONCAPI_COMPAT_MSC_INLINE
-   // These two macros are undefined at the end of this file
+#  define PYCAPI_COMPAT_INLINE(TYPE static __inline TYPE
+#else
+#  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static inline TYPE
 #endif
 
+
+// C++ compatibility
+#ifdef __cplusplus
+#  define PYCAPI_COMPAT_CAST(TYPE, EXPR) reinterpret_cast<TYPE>(EXPR)
+#  define PYCAPI_COMPAT_NULL nullptr
+#else
+#  define PYCAPI_COMPAT_CAST(TYPE, EXPR) (TYPE)(EXPR)
+#  define PYCAPI_COMPAT_NULL NULL
+#endif
 
 // Cast argument to PyObject* type.
 #ifndef _PyObject_CAST
-#  define _PyObject_CAST(op) ((PyObject*)(op))
+#  define _PyObject_CAST(op) PYCAPI_COMPAT_CAST(PyObject*, op)
 #endif
 #ifndef _PyObject_CAST_CONST
-#  define _PyObject_CAST_CONST(op) ((const PyObject*)(op))
+#  define _PyObject_CAST_CONST(op) PYCAPI_COMPAT_CAST(const PyObject*, op)
 #endif
 
 
 // bpo-42262 added Py_NewRef() to Python 3.10.0a3
 #if PY_VERSION_HEX < 0x030A00A3 && !defined(Py_NewRef)
-static inline PyObject* _Py_NewRef(PyObject *obj)
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
+_Py_NewRef(PyObject *obj)
 {
     Py_INCREF(obj);
     return obj;
@@ -55,7 +65,8 @@ static inline PyObject* _Py_NewRef(PyObject *obj)
 
 // bpo-42262 added Py_XNewRef() to Python 3.10.0a3
 #if PY_VERSION_HEX < 0x030A00A3 && !defined(Py_XNewRef)
-static inline PyObject* _Py_XNewRef(PyObject *obj)
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
+_Py_XNewRef(PyObject *obj)
 {
     Py_XINCREF(obj);
     return obj;
@@ -66,7 +77,8 @@ static inline PyObject* _Py_XNewRef(PyObject *obj)
 
 // See https://bugs.python.org/issue42522
 #if !defined(_Py_StealRef)
-static inline PyObject* __Py_StealRef(PyObject *obj)
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
+__Py_StealRef(PyObject *obj)
 {
     Py_DECREF(obj);
     return obj;
@@ -77,7 +89,8 @@ static inline PyObject* __Py_StealRef(PyObject *obj)
 
 // See https://bugs.python.org/issue42522
 #if !defined(_Py_XStealRef)
-static inline PyObject* __Py_XStealRef(PyObject *obj)
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
+__Py_XStealRef(PyObject *obj)
 {
     Py_XDECREF(obj);
     return obj;
@@ -88,7 +101,8 @@ static inline PyObject* __Py_XStealRef(PyObject *obj)
 
 // bpo-39573 added Py_SET_REFCNT() to Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_REFCNT)
-static inline void _Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt)
+PYCAPI_COMPAT_STATIC_INLINE(void)
+_Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt)
 {
     ob->ob_refcnt = refcnt;
 }
@@ -133,7 +147,7 @@ static inline void _Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt)
 
 // bpo-39573 added Py_SET_TYPE() to Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
-static inline void
+PYCAPI_COMPAT_STATIC_INLINE(void)
 _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
 {
     ob->ob_type = type;
@@ -144,7 +158,7 @@ _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
 
 // bpo-39573 added Py_SET_SIZE() to Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
-static inline void
+PYCAPI_COMPAT_STATIC_INLINE(void)
 _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
 {
     ob->ob_size = size;
@@ -155,47 +169,49 @@ _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
 
 // bpo-40421 added PyFrame_GetCode() to Python 3.9.0b1
 #if PY_VERSION_HEX < 0x030900B1
-static inline PyCodeObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyCodeObject*)
 PyFrame_GetCode(PyFrameObject *frame)
 {
-    assert(frame != NULL);
-    assert(frame->f_code != NULL);
-    return (PyCodeObject*)Py_NewRef(frame->f_code);
+    assert(frame != PYCAPI_COMPAT_NULL);
+    assert(frame->f_code != PYCAPI_COMPAT_NULL);
+    return PYCAPI_COMPAT_CAST(PyCodeObject*, Py_NewRef(frame->f_code));
 }
 #endif
 
-static inline PyCodeObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyCodeObject*)
 _PyFrame_GetCodeBorrow(PyFrameObject *frame)
 {
-    return (PyCodeObject *)_Py_StealRef(PyFrame_GetCode(frame));
+    return PYCAPI_COMPAT_CAST(PyCodeObject *,
+                              _Py_StealRef(PyFrame_GetCode(frame)));
 }
 
 
 // bpo-40421 added PyFrame_GetCode() to Python 3.9.0b1
 #if PY_VERSION_HEX < 0x030900B1 && !defined(PYPY_VERSION)
-static inline PyFrameObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyFrameObject*)
 PyFrame_GetBack(PyFrameObject *frame)
 {
-    assert(frame != NULL);
-    return (PyFrameObject*)Py_XNewRef(frame->f_back);
+    assert(frame != PYCAPI_COMPAT_NULL);
+    return PYCAPI_COMPAT_CAST(PyFrameObject*, Py_XNewRef(frame->f_back));
 }
 #endif
 
 #if !defined(PYPY_VERSION)
-static inline PyFrameObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyFrameObject*)
 _PyFrame_GetBackBorrow(PyFrameObject *frame)
 {
-    return (PyFrameObject *)_Py_XStealRef(PyFrame_GetBack(frame));
+    return PYCAPI_COMPAT_CAST(PyFrameObject *,
+                                  _Py_XStealRef(PyFrame_GetBack(frame)));
 }
 #endif
 
 
 // bpo-39947 added PyThreadState_GetInterpreter() to Python 3.9.0a5
 #if PY_VERSION_HEX < 0x030900A5
-static inline PyInterpreterState *
+PYCAPI_COMPAT_STATIC_INLINE(PyInterpreterState *)
 PyThreadState_GetInterpreter(PyThreadState *tstate)
 {
-    assert(tstate != NULL);
+    assert(tstate != PYCAPI_COMPAT_NULL);
     return tstate->interp;
 }
 #endif
@@ -203,37 +219,38 @@ PyThreadState_GetInterpreter(PyThreadState *tstate)
 
 // bpo-40429 added PyThreadState_GetFrame() to Python 3.9.0b1
 #if PY_VERSION_HEX < 0x030900B1 && !defined(PYPY_VERSION)
-static inline PyFrameObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyFrameObject*)
 PyThreadState_GetFrame(PyThreadState *tstate)
 {
-    assert(tstate != NULL);
-    return (PyFrameObject *)Py_XNewRef(tstate->frame);
+    assert(tstate != PYCAPI_COMPAT_NULL);
+    return PYCAPI_COMPAT_CAST(PyFrameObject *, Py_XNewRef(tstate->frame));
 }
 #endif
 
 #if !defined(PYPY_VERSION)
-static inline PyFrameObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyFrameObject*)
 _PyThreadState_GetFrameBorrow(PyThreadState *tstate)
 {
-    return (PyFrameObject *)_Py_XStealRef(PyThreadState_GetFrame(tstate));
+    return PYCAPI_COMPAT_CAST(PyFrameObject*,
+                              _Py_XStealRef(PyThreadState_GetFrame(tstate)));
 }
 #endif
 
 
 // bpo-39947 added PyInterpreterState_Get() to Python 3.9.0a5
 #if PY_VERSION_HEX < 0x030900A5
-static inline PyInterpreterState *
+PYCAPI_COMPAT_STATIC_INLINE(PyInterpreterState*)
 PyInterpreterState_Get(void)
 {
     PyThreadState *tstate;
     PyInterpreterState *interp;
 
     tstate = PyThreadState_GET();
-    if (tstate == NULL) {
+    if (tstate == PYCAPI_COMPAT_NULL) {
         Py_FatalError("GIL released (tstate is NULL)");
     }
     interp = tstate->interp;
-    if (interp == NULL) {
+    if (interp == PYCAPI_COMPAT_NULL) {
         Py_FatalError("no current interpreter");
     }
     return interp;
@@ -243,17 +260,18 @@ PyInterpreterState_Get(void)
 
 // bpo-39947 added PyInterpreterState_Get() to Python 3.9.0a6
 #if 0x030700A1 <= PY_VERSION_HEX && PY_VERSION_HEX < 0x030900A6 && !defined(PYPY_VERSION)
-static inline uint64_t
+PYCAPI_COMPAT_STATIC_INLINE(uint64_t)
 PyThreadState_GetID(PyThreadState *tstate)
 {
-    assert(tstate != NULL);
+    assert(tstate != PYCAPI_COMPAT_NULL);
     return tstate->id;
 }
 #endif
 
 // bpo-43760 added PyThreadState_EnterTracing() to Python 3.11.0a2
 #if PY_VERSION_HEX < 0x030B00A2 && !defined(PYPY_VERSION)
-static inline void PyThreadState_EnterTracing(PyThreadState *tstate)
+PYCAPI_COMPAT_STATIC_INLINE(void)
+PyThreadState_EnterTracing(PyThreadState *tstate)
 {
     tstate->tracing++;
 #if PY_VERSION_HEX >= 0x030A00A1
@@ -266,10 +284,11 @@ static inline void PyThreadState_EnterTracing(PyThreadState *tstate)
 
 // bpo-43760 added PyThreadState_LeaveTracing() to Python 3.11.0a2
 #if PY_VERSION_HEX < 0x030B00A2 && !defined(PYPY_VERSION)
-static inline void PyThreadState_LeaveTracing(PyThreadState *tstate)
+PYCAPI_COMPAT_STATIC_INLINE(void)
+PyThreadState_LeaveTracing(PyThreadState *tstate)
 {
-    int use_tracing = (tstate->c_tracefunc != NULL
-                       || tstate->c_profilefunc != NULL);
+    int use_tracing = (tstate->c_tracefunc != PYCAPI_COMPAT_NULL
+                       || tstate->c_profilefunc != PYCAPI_COMPAT_NULL);
     tstate->tracing--;
 #if PY_VERSION_HEX >= 0x030A00A1
     tstate->cframe->use_tracing = use_tracing;
@@ -282,10 +301,10 @@ static inline void PyThreadState_LeaveTracing(PyThreadState *tstate)
 
 // bpo-37194 added PyObject_CallNoArgs() to Python 3.9.0a1
 #if PY_VERSION_HEX < 0x030900A1
-static inline PyObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallNoArgs(PyObject *func)
 {
-    return PyObject_CallFunctionObjArgs(func, NULL);
+    return PyObject_CallFunctionObjArgs(func, PYCAPI_COMPAT_NULL);
 }
 #endif
 
@@ -293,17 +312,17 @@ PyObject_CallNoArgs(PyObject *func)
 // bpo-39245 made PyObject_CallOneArg() public (previously called
 // _PyObject_CallOneArg) in Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4
-static inline PyObject*
+PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallOneArg(PyObject *func, PyObject *arg)
 {
-    return PyObject_CallFunctionObjArgs(func, arg, NULL);
+    return PyObject_CallFunctionObjArgs(func, arg, PYCAPI_COMPAT_NULL);
 }
 #endif
 
 
 // bpo-1635741 added PyModule_AddObjectRef() to Python 3.10.0a3
 #if PY_VERSION_HEX < 0x030A00A3
-static inline int
+PYCAPI_COMPAT_STATIC_INLINE(int)
 PyModule_AddObjectRef(PyObject *module, const char *name, PyObject *value)
 {
     int res;
@@ -319,7 +338,7 @@ PyModule_AddObjectRef(PyObject *module, const char *name, PyObject *value)
 
 // bpo-40024 added PyModule_AddType() to Python 3.9.0a5
 #if PY_VERSION_HEX < 0x030900A5
-static inline int
+PYCAPI_COMPAT_STATIC_INLINE(int)
 PyModule_AddType(PyObject *module, PyTypeObject *type)
 {
     const char *name, *dot;
@@ -330,13 +349,13 @@ PyModule_AddType(PyObject *module, PyTypeObject *type)
 
     // inline _PyType_Name()
     name = type->tp_name;
-    assert(name != NULL);
+    assert(name != PYCAPI_COMPAT_NULL);
     dot = strrchr(name, '.');
-    if (dot != NULL) {
+    if (dot != PYCAPI_COMPAT_NULL) {
         name = dot + 1;
     }
 
-    return PyModule_AddObjectRef(module, name, (PyObject *)type);
+    return PyModule_AddObjectRef(module, name, _PyObject_CAST(type));
 }
 #endif
 
@@ -344,7 +363,7 @@ PyModule_AddType(PyObject *module, PyTypeObject *type)
 // bpo-40241 added PyObject_GC_IsTracked() to Python 3.9.0a6.
 // bpo-4688 added _PyObject_GC_IS_TRACKED() to Python 2.7.0a2.
 #if PY_VERSION_HEX < 0x030900A6 && !defined(PYPY_VERSION)
-static inline int
+PYCAPI_COMPAT_STATIC_INLINE(int)
 PyObject_GC_IsTracked(PyObject* obj)
 {
     return (PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj));
@@ -354,17 +373,18 @@ PyObject_GC_IsTracked(PyObject* obj)
 // bpo-40241 added PyObject_GC_IsFinalized() to Python 3.9.0a6.
 // bpo-18112 added _PyGCHead_FINALIZED() to Python 3.4.0 final.
 #if PY_VERSION_HEX < 0x030900A6 && PY_VERSION_HEX >= 0x030400F0 && !defined(PYPY_VERSION)
-static inline int
+PYCAPI_COMPAT_STATIC_INLINE(int)
 PyObject_GC_IsFinalized(PyObject *obj)
 {
-    return (PyObject_IS_GC(obj) && _PyGCHead_FINALIZED((PyGC_Head *)(obj)-1));
+    PyGC_Head *gc = PYCAPI_COMPAT_CAST(PyGC_Head *, obj) - 1;
+    return (PyObject_IS_GC(obj) && _PyGCHead_FINALIZED(gc));
 }
 #endif
 
 
 // bpo-39573 added Py_IS_TYPE() to Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_IS_TYPE)
-static inline int
+PYCAPI_COMPAT_STATIC_INLINE(int)
 _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
     return ob->ob_type == type;
 }
@@ -381,11 +401,6 @@ _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
 #  endif
 #endif
 
-
-#ifdef PYTHONCAPI_COMPAT_MSC_INLINE
-#  undef inline
-#  undef PYTHONCAPI_COMPAT_MSC_INLINE
-#endif
 
 #ifdef __cplusplus
 }

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 """
 Run the test suite on multiple Python versions.
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -23,13 +23,7 @@ CFLAGS = COMMON_FLAGS + [
     '-std=c99',
 ]
 CPPFLAGS = COMMON_FLAGS + [
-    # pythoncapi_compat.c: PyModuleDef: mixture of designated and
-    # non-designated initializers in the same initializer list is a C99
-    # extension
-    '-Wno-c99-designator',
-    # Option -Wstrict-prototypes is not valid for C++: the option comes from
-    # Python 3.5 C flags
-    '-Wno-strict-prototypes',
+    # no C++ option yet
 ]
 
 def main():

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -2,23 +2,67 @@
 import os.path
 
 
+TEST_CPP = False
 SRC_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 
 # C compiler flags for GCC and clang
-CFLAGS = ['-Wall', '-Wextra', '-Werror']
+COMMON_FLAGS = [
+    # Treat warnings as error
+    '-Werror',
+    # Enable all warnings
+    '-Wall', '-Wextra',
+    # Extra warnings
+    '-Wconversion',
+    # /usr/lib64/pypy3.7/include/pyport.h:68:20: error: redefinition of typedef
+    # 'Py_hash_t' is a C11 feature
+    "-Wno-typedef-redefinition",
+]
+CFLAGS = COMMON_FLAGS + [
+    # Use C99 for pythoncapi_compat.c which initializes PyModuleDef with a
+    # mixture of designated and non-designated initializers
+    '-std=c99',
+]
+CPPFLAGS = COMMON_FLAGS + [
+    # pythoncapi_compat.c: PyModuleDef: mixture of designated and
+    # non-designated initializers in the same initializer list is a C99
+    # extension
+    '-Wno-c99-designator',
+]
 
 def main():
     from distutils.core import setup, Extension
+    import sys
+
+    if len(sys.argv) >= 3 and sys.argv[2] == '--build-cppext':
+        global TEST_CPP
+        TEST_CPP = True
+        del sys.argv[2]
 
     cflags = ['-I' + SRC_DIR]
+    cppflags = list(cflags)
+    # Windows uses MSVC compiler
     if os.name != "nt":
         cflags.extend(CFLAGS)
+        cppflags.extend(CPPFLAGS)
 
-    ext = Extension('test_pythoncapi_compat_cext',
-                    sources=['test_pythoncapi_compat_cext.c'],
-                    extra_compile_args=cflags)
+    # C extension
+    c_ext = Extension(
+        'test_pythoncapi_compat_cext',
+        sources=['test_pythoncapi_compat_cext.c'],
+        extra_compile_args=cflags)
+    extensions = [c_ext]
 
-    setup(name="test_pythoncapi_compat", ext_modules=[ext])
+    if TEST_CPP:
+        # C++ extension
+        cpp_ext = Extension(
+            'test_pythoncapi_compat_cppext',
+            sources=['test_pythoncapi_compat_cppext.cpp'],
+            extra_compile_args=cppflags,
+            language='c++')
+        extensions.append(cpp_ext)
+
+    setup(name="test_pythoncapi_compat",
+          ext_modules=extensions)
 
 
 if __name__ == "__main__":

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -27,6 +27,9 @@ CPPFLAGS = COMMON_FLAGS + [
     # non-designated initializers in the same initializer list is a C99
     # extension
     '-Wno-c99-designator',
+    # Option -Wstrict-prototypes is not valid for C++: the option comes from
+    # Python 3.5 C flags
+    '-Wno-strict-prototypes',
 ]
 
 def main():

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -99,7 +99,12 @@ def _check_refleak(test_func, verbose):
 
 
 def run_tests(module_name):
-    display_title("Test %s" % module_name)
+    title = "Test %s" % module_name
+    if "cppext" in title:
+        title += " (C++)"
+    else:
+        title += " (C)"
+    display_title(title)
 
     testmod = import_tests(module_name)
 

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -23,8 +23,8 @@ except ImportError:
 from utils import run_command, command_stdout
 
 
-# C++ is only supported on Python 3.5 and newer
-TEST_CPP = (sys.version_info >= (3, 5))
+# C++ is only supported on Python 3.6 and newer
+TEST_CPP = (sys.version_info >= (3, 6))
 VERBOSE = False
 
 

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -43,9 +43,9 @@ def display_title(title):
 
 def build_ext():
     if TEST_CPP:
-        display_title("Build the C extension")
-    else:
         display_title("Build the C and C++ extensions")
+    else:
+        display_title("Build the C extension")
     if os.path.exists("build"):
         shutil.rmtree("build")
     cmd = [sys.executable, "setup.py", "build"]

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -23,12 +23,17 @@ except ImportError:
 from utils import run_command, command_stdout
 
 
+# C++ is only supported on Python 3.5 and newer
+TEST_CPP = (sys.version_info >= (3, 5))
 VERBOSE = False
 
 
 def display_title(title):
     if not VERBOSE:
         return
+
+    ver = sys.version_info
+    title = "Python %s.%s: %s" % (ver.major, ver.minor, title)
 
     print(title)
     print("=" * len(title))
@@ -37,11 +42,15 @@ def display_title(title):
 
 
 def build_ext():
-    display_title("Build the C extension")
+    if TEST_CPP:
+        display_title("Build the C extension")
+    else:
+        display_title("Build the C and C++ extensions")
     if os.path.exists("build"):
         shutil.rmtree("build")
-    os.environ['CFLAGS'] = "-I .."
     cmd = [sys.executable, "setup.py", "build"]
+    if TEST_CPP:
+        cmd.append('--build-cppext')
     if VERBOSE:
         run_command(cmd)
         print()
@@ -52,7 +61,7 @@ def build_ext():
             sys.exit(exitcode)
 
 
-def import_tests():
+def import_tests(module_name):
     pythonpath = None
     for name in os.listdir("build"):
         if name.startswith('lib.'):
@@ -61,8 +70,8 @@ def import_tests():
     if not pythonpath:
         raise Exception("Failed to find the build directory")
     sys.path.append(pythonpath)
-    import test_pythoncapi_compat_cext
-    return test_pythoncapi_compat_cext
+
+    return __import__(module_name)
 
 
 def _run_tests(tests, verbose):
@@ -89,8 +98,10 @@ def _check_refleak(test_func, verbose):
             raise AssertionError("refcnt leak, diff: %s" % diff)
 
 
-def run_tests(testmod):
-    display_title("Run tests")
+def run_tests(module_name):
+    display_title("Test %s" % module_name)
+
+    testmod = import_tests(module_name)
 
     check_refleak = hasattr(sys, 'gettotalrefcount')
 
@@ -131,7 +142,7 @@ def run_tests(testmod):
 
 def main():
     global VERBOSE
-    VERBOSE = "-v" in sys.argv[1:]
+    VERBOSE = ("-v" in sys.argv[1:] or "--verbose" in sys.argv[1:])
 
     if faulthandler is not None:
         faulthandler.enable()
@@ -141,8 +152,10 @@ def main():
         os.chdir(src_dir)
 
     build_ext()
-    mod = import_tests()
-    run_tests(mod)
+
+    run_tests("test_pythoncapi_compat_cext")
+    if TEST_CPP:
+        run_tests("test_pythoncapi_compat_cppext")
 
 
 if __name__ == "__main__":

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -427,7 +427,7 @@ static struct PyModuleDef module = {
     PyModuleDef_HEAD_INIT,
     MODULE_NAME_STR,     // m_name
     PYCAPI_COMPAT_NULL,  // m_doc
-    0, i                 // m_doc
+    0,                   // m_doc
     methods,             // m_methods
 #if PY_VERSION_HEX >= 0x03050000
     PYCAPI_COMPAT_NULL,  // m_slots

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -11,6 +11,14 @@
 #  define PYTHON3 1
 #endif
 
+#ifdef __cplusplus
+#  define MODULE_NAME test_pythoncapi_compat_cppext
+#  define MODULE_NAME_STR "test_pythoncapi_compat_cppext"
+#else
+#  define MODULE_NAME test_pythoncapi_compat_cext
+#  define MODULE_NAME_STR "test_pythoncapi_compat_cext"
+#endif
+
 // Ignore reference count checks on PyPy
 #if !defined(PYPY_VERSION)
 #  define CHECK_REFCNT
@@ -21,6 +29,8 @@
 #else
 #  define ASSERT_REFCNT(expr)
 #endif
+
+#define CONCAT(a, b) a ## b
 
 static PyObject *
 test_object(PyObject *Py_UNUSED(module), PyObject* Py_UNUSED(ignored))
@@ -415,21 +425,34 @@ static struct PyMethodDef methods[] = {
 #ifdef PYTHON3
 static struct PyModuleDef module = {
     PyModuleDef_HEAD_INIT,
-    .m_name = "test_pythoncapi_compat_cext",
+    .m_name = MODULE_NAME_STR,
+    .m_doc = PYCAPI_COMPAT_NULL,
+    .m_size = 0,
     .m_methods = methods,
+#if PY_VERSION_HEX >= 0x03050000
+    .m_slots = PYCAPI_COMPAT_NULL,
+#else
+    .m_reload = PYCAPI_COMPAT_NULL,
+#endif
+    .m_traverse = PYCAPI_COMPAT_NULL,
+    .m_clear = PYCAPI_COMPAT_NULL,
+    .m_free = PYCAPI_COMPAT_NULL,
 };
 
 
+#define _INIT_FUNC(name) CONCAT(PyInit_, name)
+#define INIT_FUNC _INIT_FUNC(MODULE_NAME)
+
 #if PY_VERSION_HEX >= 0x03050000
 PyMODINIT_FUNC
-PyInit_test_pythoncapi_compat_cext(void)
+INIT_FUNC(void)
 {
     return PyModuleDef_Init(&module);
 }
 #else
 // Python 3.4
 PyMODINIT_FUNC
-PyInit_test_pythoncapi_compat_cext(void)
+INIT_FUNC(void)
 {
     return PyModule_Create(&module);
 }
@@ -437,10 +460,14 @@ PyInit_test_pythoncapi_compat_cext(void)
 
 #else
 // Python 2
+
+#define _INIT_FUNC(name) CONCAT(init, name)
+#define INIT_FUNC _INIT_FUNC(MODULE_NAME)
+
 PyMODINIT_FUNC
-inittest_pythoncapi_compat_cext(void)
+INIT_FUNC(void)
 {
-    Py_InitModule4("test_pythoncapi_compat_cext",
+    Py_InitModule4(MODULE_NAME_STR,
                    methods,
                    NULL,
                    NULL,

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -425,18 +425,18 @@ static struct PyMethodDef methods[] = {
 #ifdef PYTHON3
 static struct PyModuleDef module = {
     PyModuleDef_HEAD_INIT,
-    .m_name = MODULE_NAME_STR,
-    .m_doc = PYCAPI_COMPAT_NULL,
-    .m_size = 0,
-    .m_methods = methods,
+    MODULE_NAME_STR,     // m_name
+    PYCAPI_COMPAT_NULL,  // m_doc
+    0, i                 // m_doc
+    methods,             // m_methods
 #if PY_VERSION_HEX >= 0x03050000
-    .m_slots = PYCAPI_COMPAT_NULL,
+    PYCAPI_COMPAT_NULL,  // m_slots
 #else
-    .m_reload = PYCAPI_COMPAT_NULL,
+    PYCAPI_COMPAT_NULL,  // m_reload
 #endif
-    .m_traverse = PYCAPI_COMPAT_NULL,
-    .m_clear = PYCAPI_COMPAT_NULL,
-    .m_free = PYCAPI_COMPAT_NULL,
+    PYCAPI_COMPAT_NULL,  // m_traverse
+    PYCAPI_COMPAT_NULL,  // m_clear
+    PYCAPI_COMPAT_NULL,  // m_free
 };
 
 

--- a/tests/test_pythoncapi_compat_cppext.cpp
+++ b/tests/test_pythoncapi_compat_cppext.cpp
@@ -1,0 +1,4 @@
+// C++ flavor of the C extension.
+// Reuse the whole C source code using an #include, but the file has ".cpp"
+// extension to use a C++ builder.
+#include "test_pythoncapi_compat_cext.c"


### PR DESCRIPTION
* pythoncapi_compat.h uses nullptr and reinterpret_cast<> on C++
* Add tests/test_pythoncapi_compat_cppext.cpp